### PR TITLE
feat: 添加 plum 支持

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -18,6 +18,16 @@
 yay -S rime-flypy
 ```
 
+### 从 [/plum/](https://github.com/rime/plum) 获取
+
+在 /plum/ 文件夹下执行
+
+```bash
+bash rime-install cubercsl/rime-flypy
+```
+> [!NOTE]  
+> 这一安装方式下不会编译反查码表，解决方法见 cubercsl/rime-flypy#8
+
 ### 手动安装
 
 其他 Linux 发行版可以下载仓库中的内容放置在 Rime 的系统资料夹 `/usr/share/rime-data` 或用户资料夹下。不同的发行版和输入法可能不一样。

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,0 +1,11 @@
+# recipe
+
+recipe:
+  Rx: flypy
+  description: >-
+    小鹤音形 Rime 挂接 For Linux & Android.
+install_files: >-
+    *.schema.yaml
+    *.dict.yaml
+    flypy/*.dict.yaml
+    lua/*.lua


### PR DESCRIPTION
在仓库最近一次更新后，plum无法直接使用，只能仰赖手动复制文件的方式在windows和android下进行管理，无意间发现 rime/plum#4 下的的草案是可以用的，于是自己写了一个简单的recipe配置